### PR TITLE
Sanitize some tests and put github issues as comments.

### DIFF
--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -79,9 +79,10 @@ def test_push(state_test: StateTestFiller, fork: Fork, pre: Alloc, push_opcode: 
     ],
     pr=["https://github.com/ethereum/execution-spec-tests/pull/975"],
 )
+# push_opcode is sanitized: https://github.com/ethereum/execution-spec-tests/issues/1699
 @pytest.mark.parametrize(
     "push_opcode",
-    [getattr(Op, f"PUSH{i}") for i in range(1, 33)],
+    [getattr(Op, f"PUSH{i}") for i in range(1, 23)],
     ids=lambda op: str(op),
 )
 @pytest.mark.parametrize("stack_height", range(1024, 1026))

--- a/tests/frontier/precompiles/test_precompile_absence.py
+++ b/tests/frontier/precompiles/test_precompile_absence.py
@@ -27,6 +27,7 @@ RETURNDATASIZE_OFFSET = 0x10000000000000000  # Must be greater than UPPER_BOUND
     ],
 )
 @pytest.mark.valid_from("Byzantium")
+@pytest.mark.skip(reason="https://github.com/ethereum/execution-spec-tests/issues/1700")
 def test_precompile_absence(
     state_test: StateTestFiller,
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist

- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests)/[tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned @ported_from marker.
- [ ] Tests: A PR with removal of converted JSON/YML blockchain tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
