### PR TITLE
STR-1488 & STR-1489 Add Skip Tests Plugin and Configurable Skip List to Test Suite

### DIFF
--- a/pytest-check-eip-versions.ini
+++ b/pytest-check-eip-versions.ini
@@ -16,5 +16,6 @@ addopts =
     -p pytest_plugins.shared.execute_fill
     -p pytest_plugins.forks.forks
     -p pytest_plugins.help.help
+    -p pytest_plugins.skip_list.skip_list
     -m eip_version_check
     --tb short

--- a/pytest-execute.ini
+++ b/pytest-execute.ini
@@ -18,6 +18,7 @@ addopts =
     -p pytest_plugins.execute.rpc.remote
     -p pytest_plugins.forks.forks
     -p pytest_plugins.help.help
+    -p pytest_plugins.skip_list.skip_list
     -n 4
     --tb short
     --dist load

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ addopts =
     -p pytest_plugins.forks.forks
     -p pytest_plugins.eels_resolver
     -p pytest_plugins.help.help
+    -p pytest_plugins.skip_list.skip_list
     --tb short
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
 # these customizations require the pytest-custom-report plugin

--- a/skip_tests.yaml
+++ b/skip_tests.yaml
@@ -1,0 +1,80 @@
+skip_tests:
+  ## Frontier
+  # Skip test_precompiles[fork_Prague-address_0xa-precompile_exists_True-state_test]
+  # since this test expects point evaluation precompile that we do not support
+  - tests/frontier/precompiles/test_precompiles.py::test_precompiles[fork_Prague-address_0xa-precompile_exists_True-state_test]
+  ## Cancun test skip
+  # Blanket skip all the Blob related tests
+  - tests/cancun/eip4844_blobs/*.py::*
+  - tests/cancun/eip7516_blobgasfee/*.py::*
+  # Skip specific EIP-1153 tstore/tload Prague fork tests
+  - tests/cancun/eip1153_tstore/test_basic_tload.py::test_basic_tload_transaction_begin\[fork_Prague-state_test\]
+  - tests/cancun/eip1153_tstore/test_basic_tload.py::test_basic_tload_works\[fork_Prague-state_test\]
+  - tests/cancun/eip1153_tstore/test_basic_tload.py::test_basic_tload_other_after_tstore\[fork_Prague-state_test\]
+  # Skip specific mcopy memory expansion that fail due to block gas limit
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--max_length_minus_one_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--half_max_length_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--max_dest_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--max_dest_minus_one_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--half_max_dest_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--max_src_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--max_src_minus_one_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--half_max_src_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--max_length_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--max_length_minus_one_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_empty_memory-successful_False--half_max_length_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--max_dest_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--max_dest_minus_one_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--half_max_dest_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--max_src_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--max_src_minus_one_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--half_max_src_single_byte_expansion]
+  - tests/cancun/eip5656_mcopy/test_mcopy_memory_expansion.py::test_mcopy_huge_memory_expansion[fork_Prague-evm_code_type_LEGACY-state_test-from_existent_memory-successful_False--max_length_expansion]
+  ## Pectra test skip
+  # eip7623_increase_calldata_cost - skip that require Type-3 transaction
+  - tests/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption[fork_Prague-state_test-extra_gas-type_3]
+  - tests/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumption::test_full_gas_consumption[fork_Prague-state_test-exact_gas-type_3]
+  - tests/prague/eip7623_increase_calldata_cost/test_execution_gas.py::TestGasConsumptionBelowDataFloor::test_gas_consumption_below_data_floor[fork_Prague-state_test-exact_gas-type_3]
+  - tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py::test_transaction_validity_type_3*
+  
+  # eip7702_set_code_tx
+  # Skip all the tests that require Type-3 transaction
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py::test_call_to_precompile_in_pointer_context[fork_Prague-precompile_0x000000000000000000000000000000000000000a-state_test]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py::test_pointer_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000a-state_test]
+  # Skip these faling tests that fails on reth too. We need to investigate
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-single_valid_authorization_invalid_contract_authority-check_delegated_account_first_True]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-single_valid_authorization_invalid_contract_authority-check_delegated_account_first_False]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-multiple_authorizations_empty_account_then_contract_authority-check_delegated_account_first_True]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-multiple_authorizations_empty_account_then_contract_authority-check_delegated_account_first_False]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-multiple_authorizations_eoa_then_contract_authority-check_delegated_account_first_True]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-multiple_authorizations_eoa_then_contract_authority-check_delegated_account_first_False]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-multiple_authorizations_eoa_self_sponsored_then_contract_authority-check_delegated_account_first_True]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-multiple_authorizations_eoa_self_sponsored_then_contract_authority-check_delegated_account_first_False]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-single_valid_chain_specific_authorization_single_signer-check_delegated_account_first_True]
+  - tests/prague/eip7702_set_code_tx/test_gas.py::test_account_warming[fork_Prague-state_test-single_valid_chain_specific_authorization_single_signer-check_delegated_account_first_False]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_chain_specific_id[fork_Prague-state_test]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_valid_synthetic_signatures[fork_Prague-state_test-v=0,r=1,s=1]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_valid_synthetic_signatures[fork_Prague-state_test-v=1,r=1,s=1]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_valid_synthetic_signatures[fork_Prague-state_test-v=0,r=SECP256K1N-2,s=1]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_valid_synthetic_signatures[fork_Prague-state_test-v=1,r=SECP256K1N-2,s=1]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_valid_synthetic_signatures[fork_Prague-state_test-v=0,r=1,s=SECP256K1N_OVER_2]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_using_valid_synthetic_signatures[fork_Prague-state_test-v=1,r=1,s=SECP256K1N_OVER_2]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_nonce_validity[fork_Prague-state_test-nonce=1,account_nonce=0]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_nonce_validity[fork_Prague-state_test-nonce=0,account_nonce=1]
+  - tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_empty_authorization_list[fork_Prague-state_test]
+  # eip2537_bls_12_381_precompiles
+  # Skip specific test that fail due to block gas limit
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py::test_valid_multi_inf[fork_Prague-state_test---]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py::test_invalid_multi_inf[fork_Prague-state_test---]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_valid_gas_g1msm[fork_Prague-state_test-precompile_address_12--exact_gas_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_valid_gas_g1msm[fork_Prague-state_test-precompile_address_12--one_extra_gas_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_invalid_gas_g1msm[fork_Prague-state_test-precompile_address_12--insufficient_gas_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_valid_gas_g2msm[fork_Prague-state_test-precompile_address_14--exact_gas_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_valid_gas_g2msm[fork_Prague-state_test-precompile_address_14--one_extra_gas_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_invalid_gas_g2msm[fork_Prague-state_test-precompile_address_14--insufficient_gas_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_invalid_length_g1msm[fork_Prague-state_test-precompile_address_12--input_one_byte_too_long_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_invalid_length_g1msm[fork_Prague-state_test-precompile_address_12--input_one_byte_too_short_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_invalid_length_g2msm[fork_Prague-state_test-precompile_address_14--input_one_byte_too_short_full_discount_table]
+  - tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py::test_invalid_length_g2msm[fork_Prague-state_test-precompile_address_14--input_one_byte_too_long_full_discount_table]
+  # Skip the spectest zkvm tests
+  - tests/zkevm/*.py::*

--- a/src/pytest_plugins/skip_list/__init__.py
+++ b/src/pytest_plugins/skip_list/__init__.py
@@ -1,0 +1,1 @@
+"""Skip list pytest plugin for managing test exclusions."""

--- a/src/pytest_plugins/skip_list/skip_list.py
+++ b/src/pytest_plugins/skip_list/skip_list.py
@@ -1,0 +1,102 @@
+"""
+Pytest plugin for skipping tests based on a YAML skip list file.
+
+This plugin allows specifying tests to be skipped via:
+1. A YAML file containing node IDs (default: skip_tests.yaml)
+2. Command line argument --skip-list-file to specify custom file
+3. Command line argument --skip-tests for comma-separated patterns
+
+Follows patterns established by other pytest_plugins in this codebase.
+"""
+
+import fnmatch
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add command-line options for skip list functionality."""
+    skip_group = parser.getgroup("skip_list", "Skip tests based on configured patterns")
+
+    skip_group.addoption(
+        "--skip-list-file",
+        action="store",
+        dest="skip_list_file",
+        type=Path,
+        default="skip_tests.yaml",
+        help="Path to YAML file containing test node IDs to skip (default: skip_tests.yaml)",
+    )
+
+    skip_group.addoption(
+        "--skip-tests",
+        action="store",
+        dest="skip_tests_cli",
+        default="",
+        help="Comma-separated list of test node ID patterns to skip",
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """Process skip list configuration and store patterns."""
+    skip_patterns: set[str] = set()
+
+    # Load from YAML file
+    skip_file = config.getoption("skip_list_file")
+    if skip_file and Path(skip_file).exists():
+        try:
+            with open(skip_file, "r") as f:
+                skip_data = yaml.safe_load(f) or {}
+
+            # Support both list format and dict format
+            if isinstance(skip_data, list):
+                skip_patterns.update(skip_data)
+            elif isinstance(skip_data, dict) and "skip_tests" in skip_data:
+                skip_list = skip_data["skip_tests"]
+                if isinstance(skip_list, list):
+                    skip_patterns.update(skip_list)
+
+        except (yaml.YAMLError, IOError) as e:
+            pytest.exit(f"Error reading skip list file {skip_file}: {e}")
+
+    # Load from command line
+    cli_patterns = config.getoption("skip_tests_cli")
+    if cli_patterns:
+        patterns = [p.strip() for p in cli_patterns.split(",") if p.strip()]
+        skip_patterns.update(patterns)
+
+    # Store patterns in config for use by collection hook
+    setattr(config, "_skip_list_patterns", skip_patterns)  # noqa: B010
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]) -> None:
+    """Skip items that match patterns in the skip list."""
+    skip_patterns: set[str] = getattr(config, "_skip_list_patterns", set())
+
+    if not skip_patterns:
+        return
+
+    for item in items:
+        node_id = item.nodeid
+
+        # Check if item matches any skip pattern
+        should_skip = False
+        matched_pattern = None
+
+        for pattern in skip_patterns:
+            # Support both exact match and fnmatch patterns
+            if node_id == pattern or fnmatch.fnmatch(node_id, pattern):
+                should_skip = True
+                matched_pattern = pattern
+                break
+
+        if should_skip:
+            # Add skip marker with reason
+            skip_marker = pytest.mark.skip(
+                reason=f"Skipped by skip list pattern: {matched_pattern}"
+            )
+            item.add_marker(skip_marker)


### PR DESCRIPTION
## 🗒️ Description
* Add the skip tests pytest plugin
* Add skip list `skip_tests.yaml`
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
