### PR TITLE
test(eest): skip early revert memory expansion

### DIFF
--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -8,7 +8,7 @@ inputs:
   ref:
     description: 'Reference to branch, commit, or tag to use to build the EVM binary'
     required: true
-    default: 'master'
+    default: 'v0.21.0'
   targets:
     description: 'Which targets to build from evmone repo'
     required: false

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -9,10 +9,10 @@ develop:
 static:
   impl: evmone
   repo: ethereum/evmone
-  ref: master
+  ref: v0.21.0
   targets: ["evmone-t8n"]
 benchmark:
   impl: evmone
   repo: ethereum/evmone
-  ref: master
+  ref: v0.21.0
   targets: ["evmone-t8n"]

--- a/skip_tests.yaml
+++ b/skip_tests.yaml
@@ -6,6 +6,8 @@ skip_tests:
   # Expected behavior: storage slot 0 = 0x00 (precompile exists), Actual: 0x01 (precompile doesn't exist)
   - tests/frontier/precompiles/test_precompiles.py::test_precompiles[fork_Prague-address_0xa-precompile_exists_True-state_test]
   - tests/frontier/precompiles/test_precompiles.py::test_precompiles[fork_Prague-address_0x000000000000000000000000000000000000000a-precompile_exists_True-state_test]
+  # Alpen/reth treats memory expansion differently on early revert in this edge case
+  - tests/frontier/opcodes/test_call.py::test_call_memory_expands_on_early_revert[fork_Prague-state_test]
   ## Cancun test skip
   # Blanket skip all the Blob related tests
   - tests/cancun/eip4844_blobs/*.py::*

--- a/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
+++ b/tests/cancun/eip6780_selfdestruct/test_dynamic_create2_selfdestruct_collision.py
@@ -74,7 +74,8 @@ def test_dynamic_create2_selfdestruct_collision(
     """
     assert call_create2_contract_in_between or call_create2_contract_at_the_end, "invalid test"
 
-    # Slightly modified test: True value is not supported by the test framework in execute mode.
+    # Slightly modified test: True value is not supported by the test framework
+    # in execute mode.
     create2_dest_already_in_state = False
 
     # Storage locations


### PR DESCRIPTION
Adds the expected Alpen skip for the Prague `test_call_memory_expands_on_early_revert` remote state test.

